### PR TITLE
Drawing more attention to 'Additional Info'

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,7 @@ You could join our slack team in case you need any help or have any questions. [
 
 Now let's get you started with contributing to other projects. We've compiled a list of projects with easy issues you can get started on. Check out [the list of projects in web app](https://firstcontributions.github.io/#project-list).
 
-### [Additional material](additional-material/git_workflow_scenarios/additional-material.md)
-
+If you feel like you've mastered the basics, check out these [advanced git techniques and workflow](additional-material/git_workflow_scenarios/additional-material.md). Don't be shy about creating a PR if something is missing, or if you want to contribute by adding to or updating [translations](additional-material/translations)!
 
 ## Tutorials Using Other Tools
 


### PR DESCRIPTION
Rather than a somewhat out-of-place H3 referencing "Additional Information", it seemed benign to flesh the reference out in to a paragraph format comparable with the rest of the "next steps" section, in order to draw more attention to the content therein. Several issues  seem to  request touching on advanced techniques which are already outlined comprehensively under the less-visible Additional Information directory, and this change may make that more readily apparent.